### PR TITLE
chore: bump version to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.23.0](https://github.com/vtex/external-promotion-provider-middleware/compare/v0.22.0-beta.7...v0.22.0) (2021-08-16)
+
 ## [0.22.0-beta.7](https://github.com/vtex/external-promotion-provider-middleware/compare/v0.22.0-beta.5...v0.22.0-beta.7) (2021-08-10)
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "promotion-provider-middleware",
   "vendor": "vtex",
-  "version": "0.22.0-beta.7",
+  "version": "0.23.0",
   "title": "Promotion Provider Middleware",
   "description": "Promotion provider middleware for external integrations",
   "mustUpdateAt": "2018-01-04",
@@ -41,9 +41,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "Promotion Provider Middleware",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "promotion-provider-middleware",
   "private": true,
   "license": "UNLICENSED",
-  "version": "0.22.0-beta.7",
+  "version": "0.23.0",
   "scripts": {
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json}\"",


### PR DESCRIPTION
## [0.23.0](https://github.com/vtex/external-promotion-provider-middleware/compare/v0.22.0-beta.7...v0.22.0) (2021-08-16)

* Version bump to stable